### PR TITLE
Improve Performance

### DIFF
--- a/.idea/rocket-request.iml
+++ b/.idea/rocket-request.iml
@@ -2,6 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/django-distribute" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.12 (rocket-request)" jdkType="Python SDK" />

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,12 @@
 {
-    "python.testing.unittestEnabled": false,
-    "djlint.showInstallError": false
+    "python.testing.unittestEnabled": true,
+    "djlint.showInstallError": false,
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./django-distribute/django_distribute",
+        "-p",
+        "test_*.py"
+    ],
+    "python.testing.pytestEnabled": false
 }

--- a/django-distribute/django_distribute/services/distribution.py
+++ b/django-distribute/django_distribute/services/distribution.py
@@ -31,28 +31,38 @@ def distribute_items(items: dict[str, int]) -> list[RocketSilo]:
     """
     expanded_items = expand_and_sort_items(items)
     silos = [RocketSilo()]
+    start = 0
     for item in expanded_items:
-        first_fit_silo(silos, item)
+        start = first_fit_silo(silos, item, start)
     return silos
 
 
-def first_fit_silo(silos: list[RocketSilo], item: Item) -> None:
+def first_fit_silo(silos: list[RocketSilo], item: Item, start: int) -> int:
     """
     Runs a first-fit algorithm to insert the item into a silo.
 
     Tries to add the item into the first silo with enough space.
     If there are no open silos, it is added to a new one.
 
+    The start variable is an index of the silos list, such that all
+    silos before that index are already at full capacity.
+
     :param list[RocketSilo] silos: List of silos to search through.
     :param Item item: The item to add.
-    :return: None
+    :param int start: The index of the silos list to
+    start checking whether the item can be added.
+    :return: The new starting index.
+    :rtype: int
     """
-    for silo in silos:
-        if silo.load < RocketSilo.CAPACITY and silo.add_item(item):
-            return
+    for i in range(start, len(silos)):
+        if silos[i].load < RocketSilo.CAPACITY and silos[i].add_item(item):
+            if i == start and silos[i].load == RocketSilo.CAPACITY:
+                start += 1
+            return start
     new_silo = RocketSilo()
     new_silo.add_item(item)
     silos.append(new_silo)
+    return start
 
 
 def expand_and_sort_items(items: dict[str, int]) -> list[Item]:

--- a/django-distribute/django_distribute/services/distribution.py
+++ b/django-distribute/django_distribute/services/distribution.py
@@ -31,43 +31,28 @@ def distribute_items(items: dict[str, int]) -> list[RocketSilo]:
     """
     expanded_items = expand_and_sort_items(items)
     silos = [RocketSilo()]
-    first_fit_silo(silos, expanded_items)
+    for item in expanded_items:
+        first_fit_silo(silos, item)
     return silos
 
 
-def first_fit_silo(silos: list[RocketSilo], items: list[Item]) -> None:
+def first_fit_silo(silos: list[RocketSilo], item: Item) -> None:
     """
-    Distributes items into silos using a first-fit algorithm.
+    Runs a first-fit algorithm to insert the item into a silo.
 
-    First-fit-decreasing:
-    For each item, it finds the first silo into which it can fit.
-    If it did not fit into any silo, a new one
-    is created and the item is added to it.
-
-    :param list[RocketSilo] silos: List of silos to search through.
-    :param list[Item] items: List of items to distribute.
-    :return: None
-    """
-    for item in items:
-        if not find_open_silo(silos, item):
-            new_silo = RocketSilo()
-            new_silo.add_item(item)
-            silos.append(new_silo)
-
-
-def find_open_silo(silos: list[RocketSilo], item: Item) -> bool:
-    """
     Tries to add the item into the first silo with enough space.
+    If there are no open silos, it is added to a new one.
 
     :param list[RocketSilo] silos: List of silos to search through.
     :param Item item: The item to add.
-    :return: Whether the item was added to a silo.
-    :rtype: bool
+    :return: None
     """
     for silo in silos:
-        if silo.load < 1000.0 and silo.add_item(item):
-            return True
-    return False
+        if silo.load < RocketSilo.CAPACITY and silo.add_item(item):
+            return
+    new_silo = RocketSilo()
+    new_silo.add_item(item)
+    silos.append(new_silo)
 
 
 def expand_and_sort_items(items: dict[str, int]) -> list[Item]:

--- a/django-distribute/django_distribute/services/distribution.py
+++ b/django-distribute/django_distribute/services/distribution.py
@@ -65,7 +65,7 @@ def find_open_silo(silos: list[RocketSilo], item: Item) -> bool:
     :rtype: bool
     """
     for silo in silos:
-        if silo.add_item(item):
+        if silo.load < 1000.0 and silo.add_item(item):
             return True
     return False
 

--- a/django-distribute/django_distribute/services/distribution.py
+++ b/django-distribute/django_distribute/services/distribution.py
@@ -62,6 +62,8 @@ def first_fit_silo(silos: list[RocketSilo], item: Item, start: int) -> int:
     new_silo = RocketSilo()
     new_silo.add_item(item)
     silos.append(new_silo)
+    if item[ITEM_WEIGHT] == RocketSilo.CAPACITY:
+        start += 1
     return start
 
 

--- a/django-distribute/django_distribute/tests/test_distribution.py
+++ b/django-distribute/django_distribute/tests/test_distribution.py
@@ -5,7 +5,6 @@ from django_distribute.containers.rocketsilo import RocketSilo
 from django_distribute.data.items import ITEMS, make_item
 from django_distribute.services.distribution import (
     expand_and_sort_items,
-    find_open_silo,
     first_fit_silo,
 )
 
@@ -43,38 +42,43 @@ class TestDistribution(TestCase):
     def test_find_open_silo_when_item_fits(self):
         """An item is added when there is space."""
         silo = mock_silo(True)
-        self.assertTrue(find_open_silo([silo], self.item))
+        first_fit_silo([silo], self.item)
+        silo.add_item.assert_called_once_with(self.item)
 
     def test_find_open_silo_when_item_not_fits(self):
         """No item is added when there is no space."""
         silos = [mock_silo(False), mock_silo(False), mock_silo(False)]
-        self.assertFalse(find_open_silo(silos, self.item))
+        first_fit_silo(silos, self.item)
+        silos[0].add_item.assert_called_once_with(self.item)
+        silos[1].add_item.assert_called_once_with(self.item)
+        silos[2].add_item.assert_called_once_with(self.item)
 
     def test_find_first_open_silo(self):
         """The item is added to the first open silo."""
         silos = [mock_silo(False), mock_silo(True), mock_silo(True)]
-        self.assertTrue(find_open_silo(silos, self.item))
+        first_fit_silo(silos, self.item)
         silos[1].add_item.assert_called_once_with(self.item)
         silos[2].add_item.assert_not_called()
 
     def test_first_fit_silo_when_item_fits(self):
         """The item fits into the silo."""
         silos = [mock_silo(True)]
-        first_fit_silo(silos, [self.item])
+        first_fit_silo(silos, self.item)
         silos[0].add_item.assert_called_once_with(self.item)
         self.assertEqual(len(silos), 1)
 
     def test_first_fit_silo_when_item_not_fits(self):
         """The item does not fit into any silo, so new one is opened."""
         silos = [mock_silo(False)]
-        first_fit_silo(silos, [self.item])
+        first_fit_silo(silos, self.item)
         self.assertEqual(len(silos), 2)
 
     def test_items_fill_first_existing_silo(self):
         """Existing silos are filled first."""
         silos = [RocketSilo(), mock_silo(True)]
         items = [self.item, self.item]
-        first_fit_silo(silos, items)
+        for item in items:
+            first_fit_silo(silos, item)
         self.assertEqual(len(silos), 2)
         self.assertEqual(silos[0].load, 20.0)
         silos[1].add_item.assert_not_called()
@@ -84,7 +88,8 @@ class TestDistribution(TestCase):
         silos = [RocketSilo(), mock_silo(True)]
         item = {"weight": 350}
         items = [item, item, item]
-        first_fit_silo(silos, items)
+        for item in items:
+            first_fit_silo(silos, item)
         self.assertEqual(len(silos), 2)
         self.assertEqual(silos[0].load, 700)
         silos[1].add_item.assert_called_once_with(item)
@@ -93,5 +98,6 @@ class TestDistribution(TestCase):
         """Items fill existing silos before creating a new one."""
         silos = [mock_silo(False), RocketSilo()]
         items = [{"name": "Item", "weight": 1000}, self.item]
-        first_fit_silo(silos, items)
+        for item in items:
+            first_fit_silo(silos, item)
         self.assertEqual(len(silos), 3)

--- a/django-distribute/django_distribute/tests/test_distribution.py
+++ b/django-distribute/django_distribute/tests/test_distribution.py
@@ -42,13 +42,13 @@ class TestDistribution(TestCase):
     def test_find_open_silo_when_item_fits(self):
         """An item is added when there is space."""
         silo = mock_silo(True)
-        first_fit_silo([silo], self.item)
+        first_fit_silo([silo], self.item, 0)
         silo.add_item.assert_called_once_with(self.item)
 
     def test_find_open_silo_when_item_not_fits(self):
         """No item is added when there is no space."""
         silos = [mock_silo(False), mock_silo(False), mock_silo(False)]
-        first_fit_silo(silos, self.item)
+        first_fit_silo(silos, self.item, 0)
         silos[0].add_item.assert_called_once_with(self.item)
         silos[1].add_item.assert_called_once_with(self.item)
         silos[2].add_item.assert_called_once_with(self.item)
@@ -56,21 +56,21 @@ class TestDistribution(TestCase):
     def test_find_first_open_silo(self):
         """The item is added to the first open silo."""
         silos = [mock_silo(False), mock_silo(True), mock_silo(True)]
-        first_fit_silo(silos, self.item)
+        first_fit_silo(silos, self.item, 0)
         silos[1].add_item.assert_called_once_with(self.item)
         silos[2].add_item.assert_not_called()
 
     def test_first_fit_silo_when_item_fits(self):
         """The item fits into the silo."""
         silos = [mock_silo(True)]
-        first_fit_silo(silos, self.item)
+        first_fit_silo(silos, self.item, 0)
         silos[0].add_item.assert_called_once_with(self.item)
         self.assertEqual(len(silos), 1)
 
     def test_first_fit_silo_when_item_not_fits(self):
         """The item does not fit into any silo, so new one is opened."""
         silos = [mock_silo(False)]
-        first_fit_silo(silos, self.item)
+        first_fit_silo(silos, self.item, 0)
         self.assertEqual(len(silos), 2)
 
     def test_items_fill_first_existing_silo(self):
@@ -78,7 +78,7 @@ class TestDistribution(TestCase):
         silos = [RocketSilo(), mock_silo(True)]
         items = [self.item, self.item]
         for item in items:
-            first_fit_silo(silos, item)
+            first_fit_silo(silos, item, 0)
         self.assertEqual(len(silos), 2)
         self.assertEqual(silos[0].load, 20.0)
         silos[1].add_item.assert_not_called()
@@ -89,7 +89,7 @@ class TestDistribution(TestCase):
         item = {"weight": 350}
         items = [item, item, item]
         for item in items:
-            first_fit_silo(silos, item)
+            first_fit_silo(silos, item, 0)
         self.assertEqual(len(silos), 2)
         self.assertEqual(silos[0].load, 700)
         silos[1].add_item.assert_called_once_with(item)
@@ -99,5 +99,13 @@ class TestDistribution(TestCase):
         silos = [mock_silo(False), RocketSilo()]
         items = [{"name": "Item", "weight": 1000}, self.item]
         for item in items:
-            first_fit_silo(silos, item)
+            first_fit_silo(silos, item, 0)
         self.assertEqual(len(silos), 3)
+    
+    def test_first_fit_with_index(self):
+        """Try to add the item to silos starting at the start index."""
+        silos = [mock_silo(True), mock_silo(False), mock_silo(True)]
+        first_fit_silo(silos, self.item, 1)
+        silos[0].add_item.assert_not_called()
+        silos[1].add_item.assert_called_once_with(self.item)
+        silos[2].add_item.assert_called_once_with(self.item)

--- a/django-distribute/django_distribute/tests/test_views.py
+++ b/django-distribute/django_distribute/tests/test_views.py
@@ -214,8 +214,8 @@ class DistributableViewTests(TestCase):
     @tag("slow", "profile")
     def test_profile_distribution(self):
         """Collects cProfile statistics."""
-        n1 = 10000
-        n2 = 10000
+        n1 = 100000
+        n2 = 100000
         n3 = 2
         session = self.client.session
         session["itemlist"] = {"Transport belt": n1, "Chemical plant": n2}

--- a/run.sh
+++ b/run.sh
@@ -22,20 +22,28 @@
 # Date: 2026/05/17
 # =============================================================
 
+APPDIR="django-distribute"
+PROJDIR="django-rocket-request"
+
+function clean {
+    rm $APPDIR/dist/*
+}
+
 function build {
-    python -m build django-distribute
+    clean
+    python -m build $APPDIR
 }
 
 function install {
-    pip install django-distribute/dist/django_distribute-*.tar.gz
+    pip install $APPDIR/dist/django_distribute-*.tar.gz
 }
 
 function migrate {
-    python django-rocket-request/manage.py migrate
+    python $PROJDIR/manage.py migrate
 }
 
 function runServer {
-    python django-rocket-request/manage.py runserver
+    python $PROJDIR/manage.py runserver
 }
 
 function printUsage {


### PR DESCRIPTION
Per profiling tests, the distribution of items was making many unnecessary expensive calls. To improve performance, these changes include optimizations to the function performing the first-fit algorithm.

The list of silos is iterated over to find the first open silo. The first optimization is to skip checking whether we can add items to silos at max capacity, which we know through the silo's load attribute.

The next optimization is to keep an index to start iterating over the silos at. Silos in the list prior to this index are all at max capacity, so there is no need to iterate over them.