### PR TITLE
Build date custom context processor

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   release:
+    if: github.actor != 'rocket-request[bot]'
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-release-${{ github.ref_name }}
@@ -49,7 +50,8 @@ jobs:
       
       - name: Action | Update Build Date
         run: |
-          sed -i "s|Some time ago|$(date +%F)|g" ./django-distribute/django_distribute/templates/distribute/base.html
+          echo $(date +%F) > ./django-distribute/django_distribute/BUILD_DATE
+          git add ./django-distribute/django_distribute/BUILD_DATE
 
       - name: Action | Semantic Version Release
         id: release

--- a/boot_django.py
+++ b/boot_django.py
@@ -50,6 +50,7 @@ def boot_django():
                         "django.template.context_processors.request",
                         "django.contrib.auth.context_processors.auth",
                         "django.contrib.messages.context_processors.messages",
+                        "django_distribute.context_processors.build_date",
                     ],
                 },
             },

--- a/django-distribute/django_distribute/BUILD_DATE
+++ b/django-distribute/django_distribute/BUILD_DATE
@@ -1,0 +1,1 @@
+Some time ago

--- a/django-distribute/django_distribute/context_processors.py
+++ b/django-distribute/django_distribute/context_processors.py
@@ -1,0 +1,11 @@
+"""Custom context processors."""
+
+# pylint: disable=unused-argument
+
+from pathlib import Path
+
+
+def build_date(request):
+    """Injects build date into templates."""
+    build_date_file = Path(__file__).parent / "BUILD_DATE"
+    return {"build_date": build_date_file.read_text()}

--- a/django-distribute/django_distribute/templates/distribute/base.html
+++ b/django-distribute/django_distribute/templates/distribute/base.html
@@ -72,7 +72,7 @@
                    target="_blank"
                    rel="noopener noreferrer">brufinus@duck.com</a>
             </div>
-            <div class="change-info">Updated: Some time ago</div>
+            <div class="change-info">Updated: {{ build_date }}</div>
             <div class="logo-link-box">
                 <a href="https://github.com/brufinus/rocket-request"
                    target="_blank"

--- a/django-distribute/django_distribute/tests/test_views.py
+++ b/django-distribute/django_distribute/tests/test_views.py
@@ -1,6 +1,7 @@
 """Display, request, and session tests on views."""
 
 import cProfile
+from pathlib import Path
 import pstats
 from importlib.metadata import version as get_version
 from unittest.mock import patch
@@ -95,6 +96,12 @@ class IndexViewTests(TestCase):
         """Version in the footer is set correctly."""
         response = self.client.get(reverse("distribute:index"))
         self.assertContains(response, get_version("django-distribute"))
+
+    def test_build_date(self):
+        """Build date is set by the build date context processor."""
+        expected = (Path(__file__).parent.parent / "BUILD_DATE").read_text()
+        response = self.client.get(reverse("distribute:index"))
+        self.assertContains(response, expected)
 
 
 @tag("views")

--- a/django-distribute/test_settings.py
+++ b/django-distribute/test_settings.py
@@ -33,6 +33,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "django_distribute.context_processors.build_date",
             ],
         },
     },

--- a/django-rocket-request/rocketrequest/settings.py
+++ b/django-rocket-request/rocketrequest/settings.py
@@ -61,6 +61,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                "django_distribute.context_processors.build_date"
             ],
         },
     },


### PR DESCRIPTION
Set the updated date on the base template using a custom context processor that pulls the date from an external file. The CD workflow sets the file on a successful release.